### PR TITLE
v1.0.6-beta

### DIFF
--- a/SplinterlandsRObot/API/Bot.cs
+++ b/SplinterlandsRObot/API/Bot.cs
@@ -30,8 +30,9 @@ namespace SplinterlandsRObot.API
                 questColor = questColor,
                 questCompleted = questCompleted,
                 playerCards = playerCards,
+                preferredSummoners = Settings.PREFERRED_SUMMONERS,
                 username = user.Username,
-                enemyData = usePrivateApi && Settings.USE_ENEMY_PREDICTION ? await new EnemyPrediction().GetEnemyData(matchDetails, user.Username) : new JObject()
+                enemyData = new JObject()
             };
 
             Uri url = new Uri(String.Format(Settings.API_URL + (usePrivateApi ? BOT_PRIVATE_API_GET_TEAM : BOT_PUBLIC_API_GET_TEAM)));

--- a/SplinterlandsRObot/Config/config.xml
+++ b/SplinterlandsRObot/Config/config.xml
@@ -17,11 +17,13 @@
   <Quests>
 	<DoQuests>true</DoQuests><!--Bot will prioritize teams based on active quest-->
 	<ClaimRewards>true</ClaimRewards><!--Claims quests rewards when quest completed-->
+	<DontClaimNearNextLeague>false</DontClaimNearNextLeague><!--When enabled, if rating is near a higher league and user has the power for it, it will wait to reach that league before claiming reward-->
 	<AvoidQuests>
 	  <Enabled>false</Enabled><!--If there are specific quests you would like the bot to avoid, enable this end set below the list-->
 	  <QuestList>Fire;Neutral</QuestList><!--Available options: Life,Water,Snipe,Earth,Fire,Death,Neutral,Dragon,Sneak-->
 	</AvoidQuests>
   </Quests>
+  <PreferredSummoners></PreferredSummoners><!--Usage: Kelya Frendul;Tarsa (separated by ";" and no spaces before and after.Summoners will be prioritized in the order they are set if the active splinters allow it-->
   <ProFeatures><!--This features are not available by default, dm me for details-->
 	<Airdrops>
 	  <CollectSPS>false</CollectSPS><!--If enabled will claim the Hive SPS Airdrop-->
@@ -41,6 +43,5 @@
 	  <TransferSps>false</TransferSps><!--Will transfer SPS currency to main account-->
 	</TransferBot>
 	<UsePrivateAPi>false</UsePrivateAPi><!--No Limit for API Calls-->
-	<UseEnemyPrediction>false</UseEnemyPrediction><!--Tries to predict enemy team-->
   </ProFeatures>
 </config>

--- a/SplinterlandsRObot/Config/rentcards.xml
+++ b/SplinterlandsRObot/Config/rentcards.xml
@@ -40,4 +40,12 @@
 		<rent_days>1</rent_days>
 		<currency>DEC</currency>
 	</card>
+	<card>
+		<card_detail_id>91</card_detail_id>
+		<card_edition>Reward</card_edition>
+		<is_gold>false</is_gold>
+		<price_limit>0.16</price_limit>
+		<rent_days>1</rent_days>
+		<currency>DEC</currency>
+	</card>
 </cards>

--- a/SplinterlandsRObot/Constructors/APIGetTeamPostData.cs
+++ b/SplinterlandsRObot/Constructors/APIGetTeamPostData.cs
@@ -8,6 +8,7 @@ namespace SplinterlandsRObot.Constructors
         public string questColor { get; set; }
         public bool questCompleted { get; set; }
         public CardsCollection playerCards { get; set; }
+        public string preferredSummoners { get; set; }
         public string username { get; set; }
         public JToken? enemyData { get; set; }
     }

--- a/SplinterlandsRObot/Game/BotInstance.cs
+++ b/SplinterlandsRObot/Game/BotInstance.cs
@@ -202,7 +202,7 @@ namespace SplinterlandsRObot.Game
                             if (questData.claim_trx_id == null)
                             {
                                 Logs.LogMessage($"{UserData.Username}: Trying to claim Quest Rewards", Logs.LOG_SUCCESS);
-                                if (new Quests().ClaimQuestReward(questData, UserData)) APICounter = 99;
+                                if (new Quests().ClaimQuestReward(questData, UserData, userDetails)) APICounter = 99;
                             }
                         }
                     }
@@ -618,8 +618,8 @@ namespace SplinterlandsRObot.Game
         {
             try
             {
-                int highestPossibleLeage = GetMaxLeagueByRankAndPower(userDetails.rating, userDetails.collection_power);
-                if (highestPossibleLeage > userDetails.league && userDetails.rating > 1000)
+                int highestPossibleLeague = GetMaxLeagueByRankAndPower(userDetails.rating, userDetails.collection_power);
+                if (highestPossibleLeague > userDetails.league && userDetails.rating > 1000)
                 {
                     Logs.LogMessage($"{UserData.Username}: Advancing to higher league!", Logs.LOG_SUCCESS);
                     APICounter = 100; // set api counter to 100 to reload details

--- a/SplinterlandsRObot/Game/Quests.cs
+++ b/SplinterlandsRObot/Game/Quests.cs
@@ -24,10 +24,21 @@ namespace SplinterlandsRObot.Game
             return response;
         }
 
-        public bool ClaimQuestReward(QuestData questData, User user)
+        public bool ClaimQuestReward(QuestData questData, User user, UserDetails userDetails)
         {
             try
             {
+                if (Settings.DONT_CLAIM_QUEST_NEAR_NEXT_LEAGUE)
+                {
+                    int leagueRating = SplinterlandsData.splinterlandsSettings.leagues[userDetails.league + 1].min_rating;
+                    int leaguePower = SplinterlandsData.splinterlandsSettings.leagues[userDetails.league + 1].min_power;
+
+                    if(userDetails.rating >= (leagueRating - 100) && userDetails.collection_power >= leaguePower)
+                    {
+                        Logs.LogMessage($"{user.Username}: Account rating is near a higher league, quest will not be claimed!", Logs.LOG_ALERT);
+                        return false;
+                    }
+                }
                 string tx = new HiveActions().ClaimQuest(user, questData.id);
                 Logs.LogMessage($"{user.Username}: Claimed quest reward:{tx}");
                 return true;
@@ -58,7 +69,6 @@ namespace SplinterlandsRObot.Game
                     Logs.LogMessage($"{user.Username}: New Quest available, requesting from Splinterlands...");
                     if (await new HiveActions().StartQuest(user))
                     {
-                        //APICounter = 99;
                         Logs.LogMessage($"{user.Username}: New Quest started", Logs.LOG_SUCCESS);
                         return true;
                     }

--- a/SplinterlandsRObot/Global/Constants.cs
+++ b/SplinterlandsRObot/Global/Constants.cs
@@ -6,6 +6,6 @@
         public const string SPLINTERLANDS_WEBSOCKET_URL = "wss://ws2.splinterlands.com/";
         public const string SPLINTERLANDS_VERSION = "splinterlands/0.7.139";
         public const string CONFIG_FOLDER = "Config";
-        public static string[] NOT_CHANGEABLE_SETTINGS = new string[] { "MAX_THREADS", "API_URL", "AVOID_SPECIFIC_QUESTS", "AVOID_SPECIFIC_QUESTS_LIST", "WINDOWS7" };
+        public static string[] NOT_CHANGEABLE_SETTINGS = new string[] { "MAX_THREADS", "API_URL", "AVOID_SPECIFIC_QUESTS", "AVOID_SPECIFIC_QUESTS_LIST", "WINDOWS7", "PREFERRED_SUMMONERS" };
     }
 }

--- a/SplinterlandsRObot/Global/Settings.cs
+++ b/SplinterlandsRObot/Global/Settings.cs
@@ -17,8 +17,10 @@ namespace SplinterlandsRObot
         public static bool LEAGUE_ADVANCE_TO_NEXT { get; set; }
         public static bool DO_QUESTS { get; set; }
         public static bool CLAIM_QUEST_REWARDS { get; set; }
+        public static bool DONT_CLAIM_QUEST_NEAR_NEXT_LEAGUE { get; set; }
         public static bool AVOID_SPECIFIC_QUESTS { get; private set; }
         public static string[]? AVOID_SPECIFIC_QUESTS_LIST { get; private set; }
+        public static string PREFERRED_SUMMONERS { get; private set; }
         public static bool COLLECT_SPS { get; set; }
         public static bool USE_RENTAL_BOT { get; set; }
         public static bool RENT_GOLD_ONLY { get; set; }
@@ -51,15 +53,16 @@ namespace SplinterlandsRObot
             LEAGUE_ADVANCE_TO_NEXT = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("League/AdvanceToNext").InnerText);
             DO_QUESTS = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("Quests/DoQuests").InnerText);
             CLAIM_QUEST_REWARDS = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("Quests/ClaimRewards").InnerText);
+            DONT_CLAIM_QUEST_NEAR_NEXT_LEAGUE = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("Quests/DontClaimNearNextLeague").InnerText);
             AVOID_SPECIFIC_QUESTS = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("Quests/AvoidQuests/Enabled").InnerText);
             AVOID_SPECIFIC_QUESTS_LIST = doc.DocumentElement.SelectSingleNode("Quests/AvoidQuests/QuestList").InnerText != null ? doc.DocumentElement.SelectSingleNode("Quests/AvoidQuests/QuestList").InnerText.Split(';') : new string[0];
+            PREFERRED_SUMMONERS = doc.DocumentElement.SelectSingleNode("PreferredSummoners").InnerText;
             COLLECT_SPS = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/Airdrops/CollectSPS").InnerText);
             USE_RENTAL_BOT = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/RentalBot/UseRentalBot").InnerText);
             RENT_GOLD_ONLY = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/RentalBot/RentGoldOnly").InnerText);
             MAX_PRICE_PER_500_DEC = Convert.ToDouble(doc.DocumentElement.SelectSingleNode("ProFeatures/RentalBot/MaxPricePer500DEC").InnerText);
             DAYS_TO_RENT = doc.DocumentElement.SelectSingleNode("ProFeatures/RentalBot/DaysToRent").InnerText;
             USE_PRIVATE_API = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/UsePrivateAPi").InnerText);
-            USE_ENEMY_PREDICTION = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/UseEnemyPrediction").InnerText);
             TRANSFER_BOT_MAIN_ACCOUNT = doc.DocumentElement.SelectSingleNode("ProFeatures/TransferBot/MainAccount").InnerText;
             TRANSFER_BOT_SEND_CARDS = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/TransferBot/TransferCards").InnerText);
             TRANSFER_BOT_SEND_DEC = Convert.ToBoolean(doc.DocumentElement.SelectSingleNode("ProFeatures/TransferBot/TransferDec").InnerText);

--- a/SplinterlandsRObot/Hive/HiveActions.cs
+++ b/SplinterlandsRObot/Hive/HiveActions.cs
@@ -196,30 +196,28 @@ namespace SplinterlandsRObot.Hive
 
                             CtransactionData oTransaction = hive.CreateTransaction(new object[] { custom_Json }, new string[] { user.PassCodes.PostingKey });
                             string tx = hive.broadcast_transaction(new object[] { custom_Json }, new string[] { user.PassCodes.PostingKey });
-                            for (int i = 0; i < 10; i++)
+                            
+                            await Task.Delay(15000);
+                            var rewardsRaw = await sp_api.GetTransactionDetails(tx);
+                            if (rewardsRaw.Contains(" not found"))
                             {
-                                await Task.Delay(15000);
-                                var rewardsRaw = await sp_api.GetTransactionDetails(tx);
-                                if (rewardsRaw.Contains(" not found"))
-                                {
-                                    continue;
-                                }
-                                else if (rewardsRaw.Contains("has already claimed their rewards from the specified season"))
-                                {
-                                    Logs.LogMessage($"[Season Rewards] {user.Username}: Rewards already claimed!", Logs.LOG_ALERT);
-                                }
-                                var rewards = JToken.Parse(rewardsRaw)["trx_info"]["result"];
+                                continue;
+                            }
+                            else if (rewardsRaw.Contains("has already claimed their rewards from the specified season"))
+                            {
+                                Logs.LogMessage($"[Season Rewards] {user.Username}: Rewards already claimed!", Logs.LOG_ALERT);
+                            }
+                            var rewards = JToken.Parse(rewardsRaw)["trx_info"]["result"];
 
 
-                                if (!((string)rewards).Contains("success\":true"))
-                                {
-                                    Logs.LogMessage($"[Season Rewards] {user.Username}: Error at claiming season rewards: " + (string)rewards, Logs.LOG_WARNING);
+                            if (!((string)rewards).Contains("success\":true"))
+                            {
+                                Logs.LogMessage($"[Season Rewards] {user.Username}: Error at claiming season rewards: " + (string)rewards, Logs.LOG_WARNING);
 
-                                }
-                                else if (((string)rewards).Contains("success\":true"))
-                                {
-                                    Logs.LogMessage($"[Season Rewards] {user.Username}: Successfully claimed season rewards!", Logs.LOG_SUCCESS);
-                                }
+                            }
+                            else if (((string)rewards).Contains("success\":true"))
+                            {
+                                Logs.LogMessage($"[Season Rewards] {user.Username}: Successfully claimed season rewards!", Logs.LOG_SUCCESS);
                             }
                         }
                     }

--- a/SplinterlandsRObot/Program.cs
+++ b/SplinterlandsRObot/Program.cs
@@ -64,6 +64,10 @@ class Program
                 {
                     _ = Task.Run(async () => await new QuestsRewards().ExportQuestsRewardsAsync().ConfigureAwait(false));
                 }
+                if (command == "START-DEC-REWARDS-EXPORT")
+                {
+                    _ = Task.Run(async () => await new DecRewards().ExportDecRewards().ConfigureAwait(false));
+                }
                 if (command == "START-CLAIM-SEASON-REWARDS")
                 {
                     _ = Task.Run(async () => await new HiveActions().ClaimSeasonRewards().ConfigureAwait(false));


### PR DESCRIPTION
- Added preferred summoner option. Bot will try to use the specified summoners in the order they are set in the config if the splinters allowe it (check new setting in config file)

- Added option to skip claim Quest Reward if rating is near a higher league (less than 100 rating difference) (check new setting in config file)
- Added DEC reward history export to Excel (for the last 10 days). Can be used by sending "START-DEC-REWARDS-EXPORT" command to the console
- Removed enemy prediction (Future updates of Splinterlands will make it useless)