### PR TITLE
v1.1.3

### DIFF
--- a/SplinterlandsRObot/Config/config_example.xml
+++ b/SplinterlandsRObot/Config/config_example.xml
@@ -14,10 +14,19 @@
   </ECR>
   <League>
 	<AdvanceToNext>true</AdvanceToNext><!--Bot will advance user to a higher league (Bronze->Silver, Silver->Gold)-->
+	<AdvanceRatingThreshold>100</AdvanceRatingThreshold><!--Set a threshold for the rating to be above the league limit before the bot will advance to the next one-->
   </League>
   <Quests>
 	<DoQuests>true</DoQuests><!--Bot will prioritize teams based on active quest-->
 	<FocusRate>50</FocusRate><!--Percetange of the chance the bot will try play a Focused splinter each match (Range[0-100])-->
+	<SplinterFocusOverride><!--You can set a Focus override value for each of the Splinters (Range[0-100], -1 for disabled)-->
+	  <Fire>-1</Fire>
+	  <Water>-1</Water>
+	  <Earth>-1</Earth>
+	  <Life>-1</Life>
+	  <Death>-1</Death>
+	  <Dragon>-1</Dragon>
+	</SplinterFocusOverride>
 	<ClaimRewards>true</ClaimRewards><!--Claims quests rewards when quest completed-->
 	<ShowQuestRewards>true</ShowQuestRewards><!--After claiming the quest it will display a table with the rewards in the console-->
 	<AvoidQuests>

--- a/SplinterlandsRObot/Global/Settings.cs
+++ b/SplinterlandsRObot/Global/Settings.cs
@@ -17,8 +17,15 @@ namespace SplinterlandsRObot
         public static bool ECR_WAIT_TO_RECHARGE { get; set; }
         public static double ECR_RECHARGE_LIMIT { get; set; }
         public static bool LEAGUE_ADVANCE_TO_NEXT { get; set; }
+        public static int LEAGUE_RATING_THRESHOLD { get; private set; }
         public static bool DO_QUESTS { get; set; }
         public static double FOCUS_RATE { get; private set; }
+        public static double SPLINTER_FOCUS_FIRE { get; set; }
+        public static double SPLINTER_FOCUS_WATER { get; set; }
+        public static double SPLINTER_FOCUS_EARTH { get; set; }
+        public static double SPLINTER_FOCUS_LIFE { get; set; }
+        public static double SPLINTER_FOCUS_DEATH { get; set; }
+        public static double SPLINTER_FOCUS_DRAGON { get; set; }
         public static bool CLAIM_QUEST_REWARDS { get; set; }
         public static bool SHOW_QUEST_REWARDS { get; private set; }
         public static bool AVOID_SPECIFIC_QUESTS { get; private set; }
@@ -64,11 +71,17 @@ namespace SplinterlandsRObot
             ECR_WAIT_TO_RECHARGE = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ECR/WaitToRecharge", false, "false"));
             ECR_RECHARGE_LIMIT = Convert.ToDouble(Helpers.ReadNode(rootNode, "ECR/RechargeLimit", false, "99"));
             LEAGUE_ADVANCE_TO_NEXT = Convert.ToBoolean(Helpers.ReadNode(rootNode, "League/AdvanceToNext", false, "true"));
+            LEAGUE_RATING_THRESHOLD = Convert.ToInt32(Helpers.ReadNode(rootNode, "League/AdvanceRatingThreshold", false, "0"));
             DO_QUESTS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/DoQuests", false, "true"));
             FOCUS_RATE = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/FocusRate", false, "50"));
+            SPLINTER_FOCUS_FIRE = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Fire", false, "-1"));
+            SPLINTER_FOCUS_WATER = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Water", false, "-1"));
+            SPLINTER_FOCUS_EARTH = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Earth", false, "-1"));
+            SPLINTER_FOCUS_LIFE = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Life", false, "-1"));
+            SPLINTER_FOCUS_DEATH = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Death", false, "-1"));
+            SPLINTER_FOCUS_DRAGON = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Dragon", false, "-1"));
             CLAIM_QUEST_REWARDS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/ClaimRewards", false, "true"));
             SHOW_QUEST_REWARDS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/ShowQuestRewards", false, "true"));
-            
             AVOID_SPECIFIC_QUESTS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/AvoidQuests/Enabled", false, "false"));
             AVOID_SPECIFIC_QUESTS_LIST = Helpers.ReadNode(rootNode, "Quests/AvoidQuests/QuestList", false, "none") != "none" ? Helpers.ReadNode(rootNode, "Quests/AvoidQuests/QuestList").Split(';') : new string[0];
             PREFERRED_SUMMONERS = Helpers.ReadNode(rootNode, "Cards/PreferredSummoners", false, "");

--- a/SplinterlandsRObot/ReleaseNotes.txt
+++ b/SplinterlandsRObot/ReleaseNotes.txt
@@ -1,6 +1,7 @@
-﻿Version 1.1.2 is released
+﻿Version 1.1.3
 
 Changes:
-    - Fixed bug with Focus Rate having a reversed behaviour
-    - Fixed a bug that would not reset the Focus state (completed)
-    - Fixed a bug with transition from Old Quest to new Focus
+    - Fixed renewing Focus after 24h complition
+    - Added option to set FocusRate on individual Splinter
+    - Added option to set a threshold for the rating to be above the league limit before the bot will advance to the next one
+    - Fixed a bug in the Reward chests calculation


### PR DESCRIPTION
- Fixed renewing Focus after 24h completion    
- Added option to set FocusRate on individual Splinter
- Added option to set a threshold for the rating to be above the league limit before the bot will advance to the next one
- Fixed a bug in the Reward chests calculation