### PR TITLE
- Accounts will no longer need to be all loaded at bot startup

### DIFF
--- a/SplinterlandsRObot/API/Splinterlands.cs
+++ b/SplinterlandsRObot/API/Splinterlands.cs
@@ -25,6 +25,15 @@ namespace SplinterlandsRObot.API
         const string SP_ACCESS_TOKEN = "/players/login?name=@@_username_@@&ref=&browser_id=@@_bid_@@&session_id=@@_sid_@@&sig=@@_signature_@@&ts=@@_timestamp_@@";
         const string SP_SPLINTERLANDS_CARDS = "/cards/get_details";
         const string SP_SPLINTERLANDS_SETTINGS = "/settings";
+        HttpClient client = new HttpClient();
+
+        public Splinterlands()
+        {
+            client.DefaultRequestHeaders.Add("origin", "https://splinterlands.com");
+            client.DefaultRequestHeaders.Add("referer", "https://splinterlands.com");
+            client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+            client.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.114 Safari/537.36");
+        }
 
         public async Task<List<SplinterlandsCard>> GetSplinterlandsCards()
         {
@@ -61,7 +70,7 @@ namespace SplinterlandsRObot.API
         public async Task<string> GetUserAccesToken(string username, string bid, string sid, string signature, string ts)
         {
             string result = "";
-            HttpResponseMessage response = await HttpWebRequest.client.GetAsync(API_URL + SP_ACCESS_TOKEN.Replace("@@_username_@@", username).Replace("@@_bid_@@", bid).Replace("@@_sid_@@", sid).Replace("@@_signature_@@", signature).Replace("@@_timestamp_@@",ts));
+            HttpResponseMessage response = await client.GetAsync(API_URL + SP_ACCESS_TOKEN.Replace("@@_username_@@", username).Replace("@@_bid_@@", bid).Replace("@@_sid_@@", sid).Replace("@@_signature_@@", signature).Replace("@@_timestamp_@@",ts));
             if (response.IsSuccessStatusCode)
             {
                 result = await response.Content.ReadAsStringAsync();
@@ -72,7 +81,7 @@ namespace SplinterlandsRObot.API
         {
             string result = "";
             string ts = new DateTimeOffset(DateTime.Now).ToUnixTimeMilliseconds().ToString();
-            HttpResponseMessage response = await HttpWebRequest.client.GetAsync(API_URL + SP_CARDS_COLLECTION.Replace("@@_username_@@", username).Replace("@@_timestamp_@@", ts).Replace("@@_accessToken_@@", accessToken));
+            HttpResponseMessage response = await client.GetAsync(API_URL + SP_CARDS_COLLECTION.Replace("@@_username_@@", username).Replace("@@_timestamp_@@", ts).Replace("@@_accessToken_@@", accessToken));
             if (response.IsSuccessStatusCode)
             {
                 result = await response.Content.ReadAsStringAsync();

--- a/SplinterlandsRObot/Config/config_example.xml
+++ b/SplinterlandsRObot/Config/config_example.xml
@@ -29,6 +29,9 @@
 	  <Dragon>-1</Dragon>
 	</SplinterFocusOverride>
   </Quests>
+  <Season>
+	<AutoClaimSeasonRewards>false</AutoClaimSeasonRewards><!--Automatically claims the season rewards once available-->
+  </Season>
   <Cards>
 	<PreferredSummoners></PreferredSummoners><!--Usage: Kelya Frendul;Tarsa (separated by ";" and no spaces before and after.Summoners will be prioritized in the order they are set if the active splinters allow it-->
 	<ReplaceStarterCards>true</ReplaceStarterCards><!--Will try to replace starter cards in the given team with similar owned cards-->
@@ -58,6 +61,7 @@
 	<TransferBot>
 	  <MainAccount>YourMainUser</MainAccount><!--The main account you want the assets to be transfered to-->
 	  <AutoTransferAfterFocusClaim>false</AutoTransferAfterFocusClaim><!--The assets transfer will be triggered for a user after claiming the focus rewards-->
+	  <AutoTransferAfterSeasonClaim>false</AutoTransferAfterSeasonClaim><!--The assets transfer will be triggered for a user after claiming the season rewards-->
 	  <TransferCards>false</TransferCards><!--Will transfer all user Cards, if you want some cards to not be transfered, you need to lock them-->
 	  <TransferDec>false</TransferDec><!--Will transfer DEC currency to main account-->
 	  <KeepDecAmount>15</KeepDecAmount><!--The amount of DEC you want to keed for one account-->

--- a/SplinterlandsRObot/Global/Users.cs
+++ b/SplinterlandsRObot/Global/Users.cs
@@ -8,11 +8,10 @@ namespace SplinterlandsRObot
     {
         public List<User> GetUsers()
         {
-            Logs.LogMessage("Loading users data, this may take a while...");
             XmlDocument doc = new XmlDocument();
             doc.Load(Path.Combine(Environment.CurrentDirectory, Constants.CONFIG_FOLDER, "users.xml"));
             List<User> userList = new();
-
+            int i = 0;
             foreach (XmlNode node in doc.DocumentElement.SelectNodes("user"))
             {
                 userList.Add(
@@ -26,7 +25,10 @@ namespace SplinterlandsRObot
                         },
                         ConfigFile = Helpers.ReadNode(node, "ConfigFile", false, "config.xml")
                     });
+                i++;
             }
+
+            Logs.LogMessage($"Loaded {i} users.");
 
             return userList;
         }

--- a/SplinterlandsRObot/Player/Config.cs
+++ b/SplinterlandsRObot/Player/Config.cs
@@ -28,6 +28,8 @@ namespace SplinterlandsRObot.Player
         public double FocusRateLife { get; set; }
         public double FocusRateDeath { get; set; }
         public double FocusRateDragon { get; set; }
+        //Season
+        public bool AutoClaimSeasonRewards { get; set; }
         //Cards
         public string PreferredSummoners { get; set; }
         public bool ReplaceStarterCards { get; set; }
@@ -57,6 +59,7 @@ namespace SplinterlandsRObot.Player
         //Assets transfer
         public string MainAccount { get; set; }
         public bool AutoTransferAfterFocusClaim { get; set; }
+        public bool AutoTransferAfterSeasonClaim { get; set; }
         public bool TransferCards { get; set; }
         public bool TransferDEC { get; set; }
         public double KeepDecAmount { get; set; }
@@ -100,6 +103,7 @@ namespace SplinterlandsRObot.Player
             ClaimFocusChests = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/ClaimRewards", false, "true"));
             AvoidFocus = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/AvoidQuests/Enabled", false, "false"));
             FocusBlacklist = Helpers.ReadNode(rootNode, "Quests/AvoidQuests/QuestList", false, "none") != "none" ? Helpers.ReadNode(rootNode, "Quests/AvoidQuests/QuestList").Split(';') : new string[0];
+            AutoClaimSeasonRewards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Season/AutoClaimSeasonRewards", false, "false"));
             PreferredSummoners = Helpers.ReadNode(rootNode, "Cards/PreferredSummoners", false, "");
             ReplaceStarterCards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Cards/ReplaceStarterCards", false, "true"));
             UseStarterCards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Cards/UseStarterCards", false, "true"));
@@ -120,6 +124,7 @@ namespace SplinterlandsRObot.Player
             RenewHoursBeforeEnding = Convert.ToInt32(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/RenewHoursBeforeEnding", false, "2"));
             MainAccount = Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/MainAccount", false, "YourMainUser");
             AutoTransferAfterFocusClaim = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/AutoTransferAfterFocusClaim", false, "false"));
+            AutoTransferAfterSeasonClaim = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/AutoTransferAfterSeasonClaim", false, "false"));
             TransferCards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/TransferCards", false, "false"));
             TransferDEC = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/TransferDec", false, "false"));
             KeepDecAmount = Convert.ToDouble(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/KeepDecAmount", false, "15"));

--- a/SplinterlandsRObot/Player/UserDetails.cs
+++ b/SplinterlandsRObot/Player/UserDetails.cs
@@ -46,6 +46,10 @@ namespace SplinterlandsRObot.Player
     }
     public class SeasonReward
     {
+        public int? chest_tier { get; set; }
+        public string? format { get; set; }
+        public int? max_league { get; set; }
         public int reward_packs { get; set; }
+        public int? season { get; set; }
     }
 }

--- a/SplinterlandsRObot/ReleaseNotes.txt
+++ b/SplinterlandsRObot/ReleaseNotes.txt
@@ -1,17 +1,11 @@
-﻿Version 1.1.6
+﻿Version 1.1.7-beta
 
 Changes:
-    - Added back some API calls to prevent the error with battles and user data from version 1.1.5
-    - Changed config file change detection to not spam with logs in the console
-    - Removed RentingForFocus
-    - Added a 5 minutes sleep when Splinterlands is not processing rent transaction to prevent a card to be rented multiple times
-    - Added a 5 minutes sleep for possible softbans errors;
-    - Adjusted renting to reduce the chances of getting a softban
-    - Overall code improvements to prevent/fix error that were encountered in version 1.1.5
-    - Season chests have been added to the Stats table in the console
-    - Fixed a bug that would start renew renting processes in parallel 
-    - Added counter for season chests in Stats table
-    - Updated focus rewards log to display Merits
-    - Options in settings.xml can be changed with console commands
-        DO_BATTLE=true/false
-        DEBUG_MODE=true/false
+    - Accounts will no longer need to be all loaded at bot startup
+    - Fixed a bug where Renting Bot would not stop even if CP was above the set limit
+    - Fixed issue claiming season rewards
+    - 2 new config option added
+        - AutoClaimSeasonRewards: will detect when season rewards are available and automatically claim them
+        - AutoTransferAfterSeasonClaim: will trigger the assets transfer once season rewards are claimed
+        Check config example
+


### PR DESCRIPTION
    - Fixed a bug where Renting Bot would not stop even if CP was above the set limit
    - Fixed issue claiming season rewards
    - 2 new config option added
        - AutoClaimSeasonRewards: will detect when season rewards are available and automatically claim them
        - AutoTransferAfterSeasonClaim: will trigger the assets transfer once season rewards are claimed
        Check config example