### PR TITLE
Version 1.1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
 # Splinterlands RO Bot - [Discord](https://discord.gg/PrqxhN6d9j)
 ![banner](https://d36mxiodymuqjm.cloudfront.net/website/home/bg_home_hero_chaos.jpg)
 
-Splinterlands RO Bot is a fast Battle-API interaction based bot, rebuilt from [Ultimate-Splinterlands-Bot -2](https://github.com/PCJones/Ultimate-Splinterlands-Bot-V2).
+Splinterlands RO Bot is a fast Battle-API interaction based bot.
 
 ## Bot features
 * Quests: 
 	- Bot will prioritize teams based on active quest.
 	- You can set a list of quests that you want the bot to avoid and it will request a new quest when possible
 	- Bot can claim quest rewards
+* Season:
+	- Auto claim season rewards
 * Battle:
-	- Fast battles due to blockchain interaction
+	- Fast battles no webdriver needed
 	- Multiple accounts can play in parallel
 	- Energy capture rate limit
 	- Bot can wait for the ECR to recharge to a specific value befor starting to play again
@@ -17,6 +19,8 @@ Splinterlands RO Bot is a fast Battle-API interaction based bot, rebuilt from [U
 	- Replacement of starter cards with similar higher level cards from the user collection if rulesets allow it
 * Pro features:
 	- Bot can collect Hive SPS Airdrops
+	- Claim SPS rewards
+	- Unstake SPS
 	- Transfer Bot for transfering assets to one main account (Cards, Dec, SPS, Packs)
 	- Quest rewards export to Excel for the past 30 days
 	- DEC rewards export to Excel
@@ -24,7 +28,7 @@ Splinterlands RO Bot is a fast Battle-API interaction based bot, rebuilt from [U
 	- Online stats dashboard
 
 ## Console Commands
-* START-TRANSFER-BOT (Starts the transfer process from all the accounts to the main accout)
+* START-TRANSFER-BOT (Starts the transfer process from all the accounts to the main account)
 * START-QUEST-REWARDS-EXPORT (Start the export to Excel process for all the accounts)
 * START-DEC-REWARDS-EXPORT (Start the export to Excel for all the accounts for the last 14 days)
 * START-CLAIM-SEASON-REWARDS (Starts the process for claiming Season Rewards)
@@ -32,32 +36,15 @@ Splinterlands RO Bot is a fast Battle-API interaction based bot, rebuilt from [U
 Settings that can be changed withoud restarting the application (**Changes will not be saved to config file!**)
 * HOLD_CACHE_FOR=NUMBER
 * DEBUG_MODE=true/false
-* SLEEP_BETWEEN_BATTLES=NUMBER
-* SHOW_BATTLE_RESULTS=true/false
-* ECR_LIMIT=NUMBER
-* ECR_WAIT_TO_RECHARGE=true/false
-* ECR_RECHARGE_LIMIT=NUMBER
-* LEAGUE_ADVANCE_TO_NEXT=true/false
-* DO_QUESTS=true/false
-* COLLECT_SPS=true/false
-* USE_PRIVATE_API=true/false
-* TRANSFER_BOT_MAIN_ACCOUNT=TEXT(USERNAME)
-* TRANSFER_BOT_SEND_CARDS=true/false
-* TRANSFER_BOT_SEND_DEC=true/false
-* TRANSFER_BOT_KEEP_DEC_AMOUNT=NUMBER
-* TRANSFER_BOT_MINIMUM_DEC_TO_TRANSFER=NUMBER
-* TRANSFER_BOT_SEND_SPS=true/false
 
 ## Setup guide
 - Download the lates version from [Release page](https://github.com/Alinubu/SplinterlandsRObot/releases)
 - Unzip the downloaded file
 - Open users_example.xml with your favorite text editor and fill the required user data and save it as users.xml
 - Open config_example.xml with your favorite text editor and adjust the settings to your needs and save it as config.xml
+- Open settings_example.xml with your favorite text editor and adjust the settings to your needs and save it as settings.xml
 - Linux/Mac Only! Run ****sudo chmod +x SplinterlandsRObot**** before starting the bot
 - Run the SplinterlandsRObot file
-
-## Config settings
-View the detailed configuration list [here](http://splinterlandsrobot.com/#!/BotConfigs)
 
 ## Support & Community
 [Discord](https://discord.gg/PrqxhN6d9j)

--- a/SplinterlandsRObot/Config/config_example.xml
+++ b/SplinterlandsRObot/Config/config_example.xml
@@ -6,6 +6,7 @@
 	<WaitToRecharge>false</WaitToRecharge><!--After the lower limit is reached, bot will wait until accout ECR is at the set value-->
 	<RechargeLimit>99</RechargeLimit><!--ECR value to recharge to-->
   </ECR>
+  <PowerLimit>0</PowerLimit><!--Used by Rental Bot and FocusStartMinimumCP option. When user CP is below limit it will be added to the renting queue-->
   <BattleMode>modern</BattleMode><!--Ranked battle mode. Options: modern or wild-->
   <League>
 	<AdvanceToNext>true</AdvanceToNext><!--Bot will advance user to a higher league (Bronze->Silver, Silver->Gold)-->
@@ -15,6 +16,8 @@
   <Quests>
 	<DoQuests>true</DoQuests><!--Bot will prioritize teams based on active quest-->
 	<ClaimRewards>true</ClaimRewards><!--Claims quests rewards when quest completed-->
+	<FocusStartMinimumCP>0</FocusStartMinimumCP><!--Minimun account CP to start a daily focus-->
+	<FocusMinimumRating>0</FocusMinimumRating><!--If rating is below this value the bot will not play teams for the focus-->
 	<AvoidQuests>
 	  <Enabled>false</Enabled><!--If there are specific quests you would like the bot to avoid, enable this end set below the list-->
 	  <QuestList>Fire;Neutral</QuestList><!--Available options: Life,Water,Snipe,Earth,Fire,Death,Neutral,Dragon,Sneak-->
@@ -33,7 +36,7 @@
 	<AutoClaimSeasonRewards>false</AutoClaimSeasonRewards><!--Automatically claims the season rewards once available-->
   </Season>
   <Cards>
-	<PreferredSummoners></PreferredSummoners><!--Usage: Kelya Frendul;Tarsa (separated by ";" and no spaces before and after.Summoners will be prioritized in the order they are set if the active splinters allow it-->
+	<PreferredSummoners></PreferredSummoners><!--Usage: Kelya Frendul;Tarsa (separated by ";" and no spaces before and after.Summoners will be prioritized based on the api ranking logic and in no specific order-->
 	<ReplaceStarterCards>true</ReplaceStarterCards><!--Will try to replace starter cards in the given team with similar owned cards-->
 	<UseStarterCards>true</UseStarterCards><!--When disabled it will only used owned or rented cards, the starter/ghost cards will be excluded-->
   </Cards>
@@ -43,14 +46,21 @@
 	  <CollectSPS>false</CollectSPS><!--If enabled will claim the Hive SPS Airdrop-->
 	  <CheckForAirdropEvery>5</CheckForAirdropEvery><!--(Hours)-->
 	</Airdrops>
+	<SPS>
+	  <ClaimSPSRewards>false</ClaimSPSRewards><!--If enabled the bot will claim the staking rewards-->
+	  <ClaimSPSRewardsEvery>24</ClaimSPSRewardsEvery><!--(Hours) Will claim SPS rewards every set hours.-->
+	  <UnstakeSPS>false</UnstakeSPS><!--If enabled the bot will automatically unstake SPS-->
+	  <MinimumSPSUnstakeAmount>100</MinimumSPSUnstakeAmount><!--Minimum value of staked SPS at which the bot to unstake-->
+	  <UnstakeWeekly>false</UnstakeWeekly><!--If enabled the bot will cancel the current unstaking after the first 25% is received and post a new unstake-->
+	</SPS>
 	<RentalBot>
 	  <UseRentalBot>false</UseRentalBot><!--Enables the renting features, all settings below will be ignored if this is disabled-->
-	  <PowerLimit>0</PowerLimit><!--Used by Rental Bot. When user CP is below limit it will be added to the renting queue-->
 	  <BattleWhileRenting>false</BattleWhileRenting><!--Accounts will continue to battle even if CP is below PowerLimit-->
-	  <DaysToRent>1</DaysToRent><!--Number of days a card should be rented for-->
+	  <DaysToRent>2</DaysToRent><!--Number of days a card should be rented for-->
 	  <MaxTriesPerUser>999999</MaxTriesPerUser><!--Number of times it should try to rent the cards for one user before moving to the next one-->
 	  <RentSpecificCards>false</RentSpecificCards><!--Will prioritize renting the cards setup in the rentConfig set for each user-->
-	  <RentFile>rentcards_example.xml</RentFile>
+	  <GroupCardsAmount></GroupCardsAmount><!--How many cards to try and group in one transaction. Recommanded value is 5, the higher the value is it will increase the chanches of softbans-->
+	  <RentFile>rentcards_example.xml</RentFile><!--The name of the renting configuration file in the Config folder-->
 	  <RentForPower>false</RentForPower><!--Will rent any card that matches de configured parameters-->
 	  <RentGoldOnly>false</RentGoldOnly><!--When renting for Power, if enabled, bot will only check the gold cards-->
 	  <CPperDecLimit>250</CPperDecLimit><!--Set the minimum CP/DEC for renting-->

--- a/SplinterlandsRObot/Config/settings_example.xml
+++ b/SplinterlandsRObot/Config/settings_example.xml
@@ -2,8 +2,14 @@
 <settings>
 	<DoBattle>true</DoBattle>
 	<MaxThreads>1</MaxThreads><!--The number of accounts the bot will play in parallel-->
-	<HoldCacheFor>30</HoldCacheFor><!--Time in minutes the bot will cache data from splinterlands-->
+	
 	<DebugMode>false</DebugMode><!--Just enable this if you have issues, will diplay a lot more logs in the console-->
 	<ApiUrl>http://api.splinterlandsrobot.com:5000</ApiUrl><!--DON'T CHANGE THIS UNLESS INSTRUCTED SO-->
-	<HiveNode>https://anyx.io/</HiveNode>
+	<HiveNode>https://anyx.io/</HiveNode><!--Hive blockchain node address-->
+	<Proxy><!--Proxy usage when calling Splinterlands API-->
+		<ProxyUrl></ProxyUrl>
+		<ProxyPort></ProxyPort>
+		<ProxyUsername></ProxyUsername>
+		<ProxyPassword></ProxyPassword>
+	</Proxy>
 </settings>

--- a/SplinterlandsRObot/Game/BattleService.cs
+++ b/SplinterlandsRObot/Game/BattleService.cs
@@ -1,0 +1,184 @@
+﻿using HiveAPI.CS;
+using SplinterlandsRObot.Global;
+using SplinterlandsRObot.Hive;
+using SplinterlandsRObot.Player;
+using SplinterlandsRObot.Net;
+using static HiveAPI.CS.CHived;
+using Newtonsoft.Json.Linq;
+using SplinterlandsRObot.Cards;
+
+namespace SplinterlandsRObot.Game
+{
+    public class BattleService
+    {
+        HiveService hive;
+        WebClient client;
+        private const string BATTLE = "battle/battle_tx";
+        private const string ORIGIN = "https://splinterlands.com";
+        private const string REFERER = "https://splinterlands.com";
+
+        public BattleService()
+        {
+            hive = new HiveService();
+            client = new WebClient(Constants.SPLINTERLANDS_BATTLE_API, ORIGIN, REFERER,Settings.PROXY_URL,Settings.PROXY_PORT, Settings.PROXY_USERNAME, Settings.PROXY_PASSWORD);
+        }
+
+        public async Task<string> StartBattle(User user, string battleMode)
+        {
+            string matchType = battleMode == "modern" ? "Modern Ranked" : "Wild Ranked";
+            string n = Helpers.RandomString(10);
+            string json = "{\"match_type\":\"" + matchType + "\",\"app\":\"" + Constants.APP_VERSION + "\",\"n\":\"" + n + "\"}";
+
+            COperations.custom_json custom_Json = hive.CreateCustomJson(user, false, true, "sm_find_match", json);
+
+            try
+            {
+                Logs.LogMessage($"{user.Username}: Finding match...");
+                CtransactionData oTransaction = hive.CreateTransaction(custom_Json, user.Keys.PostingKey);
+                string postData = hive.ParseTransactionData(oTransaction);
+                string response = await client.PostAsync(postData, BATTLE);
+                Logs.LogMessage($"{user.Username}: {response}", Logs.LOG_ALERT, supress: true);
+                if (response == "")
+                    return "";
+                if (!response.Contains("success"))
+                    return "error";
+
+                string responseTx = Helpers.DoQuickRegex("id\":\"(.*?)\"", response);
+                return responseTx;
+            }
+            catch (Exception ex)
+            {
+                Logs.LogMessage($"{user.Username}: Error at finding match: " + ex.ToString(), Logs.LOG_WARNING);
+            }
+            return "";
+        }
+
+        public async Task<(string secret, string tx)> SubmitTeam(string tx, JToken matchDetails, JToken team, User user, CardsCollection CardsCached)
+        {
+            try
+            {
+                string summoner = team["summoner"].ToString();
+                string monsters = "";
+                for (int i = 1; i <= 6; i++)
+                {
+                    string monster = team[$"card{i}"].ToString();
+
+                    if (monster != "")
+                    {
+                        if (monster.Length == 0)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                    monsters += "\"" + monster + "\",";
+                }
+                monsters = monsters[..^1];
+
+                string secret = Helpers.RandomString(10);
+                string n = Helpers.RandomString(10);
+
+                string monsterClean = monsters.Replace("\"", "");
+
+                string teamHash = Helpers.GenerateMD5Hash(summoner + "," + monsterClean + "," + secret);
+
+                string json = "{\"trx_id\":\"" + tx + "\",\"team_hash\":\"" + teamHash + "\",\"app\":\"" + Constants.APP_VERSION + "\",\"n\":\"" + n + "\"}";
+
+                COperations.custom_json custom_Json = hive.CreateCustomJson(user, false, true, "sm_submit_team", json);
+
+                Logs.LogMessage($"{user.Username}: Submitting team...");
+                CtransactionData oTransaction = hive.CreateTransaction(custom_Json, user.Keys.PostingKey);
+                string postData = hive.ParseTransactionData(oTransaction);
+                string response = await client.PostAsync(postData, BATTLE);
+                string responseTx = Helpers.DoQuickRegex("id\":\"(.*?)\"", response);
+                return (secret, responseTx);
+            }
+            catch (Exception ex)
+            {
+                Logs.LogMessage($"{user.Username}: Error at submitting team: " + ex.ToString(), Logs.LOG_WARNING);
+            }
+            return ("", "");
+        }
+
+        public async Task<bool> RevealTeam(string tx, JToken matchDetails, JToken team, string secret, User user, CardsCollection CardsCached)
+        {
+            try
+            {
+                string summoner = team["summoner"].ToString();
+                string monsters = "";
+                for (int i = 1; i <= 6; i++)
+                {
+                    string monster = team[$"card{i}"].ToString();
+
+                    if (monster != "")
+                    {
+                        if (monster.Length == 0)
+                        {
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                    monsters += "\"" + monster + "\",";
+                }
+                monsters = monsters[..^1];
+
+                string n = Helpers.RandomString(10);
+
+                string monsterClean = monsters.Replace("\"", "");
+
+
+                string json = "{\"trx_id\":\"" + tx + "\",\"summoner\":\"" + summoner + "\",\"monsters\":[" + monsters + "],\"secret\":\"" + secret + "\",\"app\":\"" + Constants.APP_VERSION + "\",\"n\":\"" + n + "\"}";
+
+                COperations.custom_json custom_Json = hive.CreateCustomJson(user, false, true, "sm_team_reveal", json);
+
+                Logs.LogMessage($"{user.Username}: Revealing team...");
+                CtransactionData oTransaction = hive.CreateTransaction(custom_Json, user.Keys.PostingKey);
+                string postData = hive.ParseTransactionData(oTransaction);
+                string response = await client.PostAsync(postData, BATTLE);
+                string responseTx = Helpers.DoQuickRegex("id\":\"(.*?)\"", response);
+
+                if (responseTx == "")
+                    return false;
+            }
+            catch (Exception ex)
+            {
+                Logs.LogMessage($"{user.Username}: Error at revealing team: " + ex.ToString(), Logs.LOG_WARNING);
+                return false;
+            }
+            return true;
+        }
+
+        public async Task<bool> SurrenderBattle(string battleId, User user)
+        {
+            try
+            {
+                string n = Helpers.RandomString(10);
+                string json = "{\"battle_queue_id\":\"" + battleId + "\",\"app\":\"" + Constants.APP_VERSION + "\",\"n\":\"" + n + "\"}";
+                Logs.LogMessage($"{user.Username}: Surrendering battle...");
+                COperations.custom_json custom_json = hive.CreateCustomJson(user, false, true, "sm_surrender", json);
+                CtransactionData oTransaction = hive.CreateTransaction(custom_json, user.Keys.PostingKey);
+                string postData = hive.ParseTransactionData(oTransaction);
+                string response = await client.PostAsync(postData, BATTLE);
+                string responseTx = Helpers.DoQuickRegex("id\":\"(.*?)\"", response);
+
+                if (responseTx == "")
+                    return false;
+            }
+            catch (Exception ex)
+            {
+                Logs.LogMessage($"{user.Username}: Error surrendering battle: " + ex.ToString(), Logs.LOG_WARNING);
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/SplinterlandsRObot/Global/Constants.cs
+++ b/SplinterlandsRObot/Global/Constants.cs
@@ -3,8 +3,8 @@
     public static class Constants
     {
         public const string SPLINTERLANDS_WEBSOCKET_URL = "wss://ws2.splinterlands.com/";
-        public const string APP_VERSION = "SplinterladsRObot 2.0.0";
-        public const string SPLINTERLANDS_BATTLE_API = "https://battle.splinterlands.com/battle/battle_tx";
+        public const string APP_VERSION = "SplinterlandsRObot 1.1.8";
+        public const string SPLINTERLANDS_BATTLE_API = "https://battle.splinterlands.com";
         public const string USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0";
         public const string CONFIG_FOLDER = "Config";
         public static string[] NOT_CHANGEABLE_SETTINGS = new string[] { "MAX_THREADS", "API_URL", "HIVE_NODE" };

--- a/SplinterlandsRObot/Global/InstanceManager.cs
+++ b/SplinterlandsRObot/Global/InstanceManager.cs
@@ -72,11 +72,25 @@ namespace SplinterlandsRObot
                 lock (_TaskLock)
                 {
                     if (!isRentingServiceRunning)
+                    {
                         _ = Task.Run(async () => await RentProcess.StartRentingProcess(token).ConfigureAwait(false));
+                        isRentingServiceRunning = true;
+                        Task.Delay(1500);
+                    }
+
                     if (!isRenewRentingServiceRunning)
+                    {
                         _ = Task.Run(async () => await RentProcess.RenewRentals()).ConfigureAwait(false);
+                        isRenewRentingServiceRunning = true;
+                        Task.Delay(1500);
+                    }
+
                     if (!isStatsSyncRunning)
+                    {
                         _ = Task.Run(async () => await new Bot().SyncUserStats(identifier, token).ConfigureAwait(false));
+                        isStatsSyncRunning = true;
+                        Task.Delay(1500);
+                    }
                 }
 
                 while (instances.Count < Settings.MAX_THREADS && !token.IsCancellationRequested)

--- a/SplinterlandsRObot/Global/Logs.cs
+++ b/SplinterlandsRObot/Global/Logs.cs
@@ -8,7 +8,7 @@ namespace SplinterlandsRObot
         public static string LOG_SUCCESS = "SUCCESS";
         public static string LOG_ALERT = "ALERT";
         public static string LOG_WARNING = "WARNING";
-        public static string[] CONSOLE_TABLE_HEADER = new string[] { "Account", "ECR", "W", "D", "L", "Winrate", "Last Reward", "Total Rewards", "Rating", "CP", "Focus [Chests|FP]", "SC" };
+        public static string[] CONSOLE_TABLE_HEADER = new string[] { "Account", "ECR", "W", "D", "L", "Winrate", /*"Last Reward", "Total Rewards", */"Rating", "CP", "Focus [Chests|FP]", "SC" };
         public static string[] CONSOLE_TABLE_TEAM = new string[] { "Summoner", "Monster1", "Monster2", "Monster3", "Monster4", "Monster5", "Monster6" };
         public static object _lock = new object();
 
@@ -52,7 +52,7 @@ namespace SplinterlandsRObot
         public static void OutputStat()
         {
             var table = new ConsoleTable(CONSOLE_TABLE_HEADER);
-            InstanceManager.UsersStatistics.ForEach(u => table.AddRow(u.Account, Math.Round(u.Balance.ECR,2), u.Wins, u.Draws, u.Losses, Math.Round((Convert.ToDouble(u.Wins) / ((u.Wins + u.Draws + u.Losses) == 0 ? Convert.ToDouble(1) : Convert.ToDouble((u.Wins + u.Draws + u.Losses))) * Convert.ToDouble(100)),2).ToString() + "%", u.MatchRewards, Math.Round(Convert.ToDouble(u.TotalRewards),3), u.Rating + "[" + u.RatingChange + "]", u.CollectionPower, u.Quest, u.Season));
+            InstanceManager.UsersStatistics.ForEach(u => table.AddRow(u.Account, Math.Round(u.Balance.ECR,2), u.Wins, u.Draws, u.Losses, Math.Round((Convert.ToDouble(u.Wins) / ((u.Wins + u.Draws + u.Losses) == 0 ? Convert.ToDouble(1) : Convert.ToDouble((u.Wins + u.Draws + u.Losses))) * Convert.ToDouble(100)),2).ToString() + "%", /*u.MatchRewards, Math.Round(Convert.ToDouble(u.TotalRewards),3),*/ u.Rating + "[" + u.RatingChange + "]", u.CollectionPower, u.Quest, u.Season));
             table.Configure(o => o.NumberAlignment = Alignment.Right);
             table.Configure(table => table.EnableCount = false);
             lock (_lock)

--- a/SplinterlandsRObot/Global/Settings.cs
+++ b/SplinterlandsRObot/Global/Settings.cs
@@ -8,9 +8,13 @@ namespace SplinterlandsRObot
     {
         public static bool DO_BATTLE { get; private set; }
         public static int MAX_THREADS { get; private set; }
-        public static bool DEBUG_MODE { get; set; }
+        public static bool DEBUG_MODE { get; private set; }
         public static string? API_URL { get; private set; }
         public static string? HIVE_NODE { get; private set; }
+        public static string? PROXY_URL { get; private set; }
+        public static string? PROXY_PORT { get; private set; }
+        public static string? PROXY_USERNAME { get; private set; }
+        public static string? PROXY_PASSWORD { get; private set; }
 
         public static void LoadSettings()
         {
@@ -22,6 +26,10 @@ namespace SplinterlandsRObot
             DEBUG_MODE = Convert.ToBoolean(Helpers.ReadNode(rootNode, "DebugMode", false, "false"));
             API_URL = Helpers.ReadNode(rootNode, "ApiUrl", false, "http://api.splinterlandsrobot.com:5000");
             HIVE_NODE = Helpers.ReadNode(rootNode, "HiveNode", false, "https://anyx.io/");
+            PROXY_URL = Helpers.ReadNode(rootNode, "Proxy/ProxyUrl", false, null);
+            PROXY_PORT = Helpers.ReadNode(rootNode, "Proxy/ProxyPort", false, null);
+            PROXY_USERNAME = Helpers.ReadNode(rootNode, "Proxy/ProxyUsername", false, null);
+            PROXY_PASSWORD = Helpers.ReadNode(rootNode, "Proxy/ProxyPassword", false, null);
         }
 
         public static void ChangeConfig(string settingName, string settingValue)

--- a/SplinterlandsRObot/Global/Users.cs
+++ b/SplinterlandsRObot/Global/Users.cs
@@ -21,7 +21,9 @@ namespace SplinterlandsRObot
                         Keys = new Keys()
                         {
                             ActiveKey = Helpers.ReadNode(node, "activeKEY", false, "none"),
-                            PostingKey = Helpers.ReadNode(node, "postingKEY", true)
+                            PostingKey = Helpers.ReadNode(node, "postingKEY", true),
+                            JwtToken = null,
+                            JwtExpire = DateTime.MinValue
                         },
                         ConfigFile = Helpers.ReadNode(node, "ConfigFile", false, "config.xml")
                     });

--- a/SplinterlandsRObot/Net/WebClient.cs
+++ b/SplinterlandsRObot/Net/WebClient.cs
@@ -1,0 +1,73 @@
+﻿using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace SplinterlandsRObot.Net
+{
+    public class WebClient
+    {
+        HttpClient client;
+        WebProxy? proxy = null;
+        NetworkCredential? networkCredential = null;
+        HttpClientHandler? httpClientHandler = null;
+
+        public WebClient(string url, string? origin = "", string? referer = "", string? proxyUrl = null, string? proxyPort = null, string? proxyUser = null, string? proxyPassword = null)
+        {
+            if (proxyUrl is not null && proxyPort is not null)
+            {
+                proxy = new WebProxy()
+                {
+                    Address = new Uri($"http://{proxyUrl}:{proxyPort}"),
+                    BypassProxyOnLocal = false,
+                    UseDefaultCredentials = false
+                };
+
+                if (proxyUser is not null && proxyPassword is not null)
+                {
+                    networkCredential = new NetworkCredential(proxyUser, proxyPassword);
+                    proxy.Credentials = networkCredential;
+                }  
+            }
+
+            if (proxy is not null)
+            {
+                httpClientHandler = new HttpClientHandler() { Proxy = proxy };
+            }
+
+            if (httpClientHandler is not null)
+                client = new HttpClient(httpClientHandler, false);
+            else client = new HttpClient();
+
+            Uri uri = new Uri(url);
+            client.BaseAddress = uri;
+
+            client.DefaultRequestHeaders.Add("origin", origin);
+            client.DefaultRequestHeaders.Add("referer", referer);
+            client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
+            client.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.114 Safari/537.36");
+        }
+
+        public async Task<string> PostAsync(string postData, string path)
+        {
+            var content = new StringContent(postData, Encoding.UTF8, "application/x-www-form-urlencoded");
+            var response = await client.PostAsync(client.BaseAddress + path, content);
+            return await response.Content.ReadAsStringAsync();
+        }
+
+        public async Task<string> GetAsync(string path, AuthenticationHeaderValue? authHeader = null)
+        {
+            if (authHeader is not null) { client.DefaultRequestHeaders.Authorization = authHeader; }
+            else { client.DefaultRequestHeaders.Remove("Authorization"); }
+
+            HttpResponseMessage response = await client.GetAsync(client.BaseAddress + path);
+            if (response.IsSuccessStatusCode)
+            {
+                return await response.Content.ReadAsStringAsync();
+            }
+            else
+            {
+                throw new HttpRequestException(response.StatusCode.ToString());
+            }
+        }
+    }
+}

--- a/SplinterlandsRObot/Player/Config.cs
+++ b/SplinterlandsRObot/Player/Config.cs
@@ -10,6 +10,7 @@ namespace SplinterlandsRObot.Player
         public double EcrLimit { get; set; }
         public bool WaitToRechargeEcr { get; set; }
         public double EcrRechargeLimit { get; set; }
+        public int PowerLimit { get; set; }
         //Battle mode
         public string BattleMode { get; set; }
         //League
@@ -19,6 +20,8 @@ namespace SplinterlandsRObot.Player
         //Focus
         public bool FocusEnabled { get; set; }
         public bool ClaimFocusChests { get; set; }
+        public int FocusStartMinimumCP { get; set; }
+        public int FocusMinimumRating { get; set; }
         public bool AvoidFocus { get; set; }
         public string[] FocusBlacklist { get; set; }
         public double FocusRate { get; set; }
@@ -39,13 +42,18 @@ namespace SplinterlandsRObot.Player
         //SPS
         public bool ClaimSPS { get; set; }
         public int CheckForAirdropEvery { get; set; }
+        public bool ClaimSPSRewards { get; set; }
+        public int ClaimSPSRewardsEvery { get; set; }
+        public bool UnstakeSPS { get; set; }
+        public double MinimumSPSUnstakeAmount { get; set; }
+        public bool UnstakeWeekly { get; set; }
         //Rentals
         public bool EnableRentals { get; set; }
-        public int PowerLimit { get; set; }
         public bool BattleWhileRenting { get; set; }
         public string DaysToRent { get; set; }
         //Rent file
         public bool UseRentFile { get; set; }
+        public int GroupCardsAmount { get; set; }
         public string RentFile { get; set; }
         public int MaxTriesPerAccount { get; set; }
         //Rent for Power
@@ -88,6 +96,7 @@ namespace SplinterlandsRObot.Player
             EcrLimit = Convert.ToDouble(Helpers.ReadNode(rootNode, "ECR/Limit", false, "75"));
             WaitToRechargeEcr = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ECR/WaitToRecharge", false, "false"));
             EcrRechargeLimit = Convert.ToDouble(Helpers.ReadNode(rootNode, "ECR/RechargeLimit", false, "99"));
+            PowerLimit = Convert.ToInt32(Helpers.ReadNode(rootNode, "PowerLimit", false, "0"));
             BattleMode = Helpers.ReadNode(rootNode, "BattleMode", false, "modern");
             LeagueAdvance = Convert.ToBoolean(Helpers.ReadNode(rootNode, "League/AdvanceToNext", false, "true"));
             LeagueRatingThreshold = Convert.ToInt32(Helpers.ReadNode(rootNode, "League/AdvanceRatingThreshold", false, "0"));
@@ -101,6 +110,8 @@ namespace SplinterlandsRObot.Player
             FocusRateDeath = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Death", false, "-1"));
             FocusRateDragon = Convert.ToDouble(Helpers.ReadNode(rootNode, "Quests/SplinterFocusOverride/Dragon", false, "-1"));
             ClaimFocusChests = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/ClaimRewards", false, "true"));
+            FocusStartMinimumCP = Convert.ToInt32(Helpers.ReadNode(rootNode, "Quests/FocusStartMinimumCP", false, "0"));
+            FocusMinimumRating = Convert.ToInt32(Helpers.ReadNode(rootNode, "Quests/FocusMinimumRating", false, "0"));
             AvoidFocus = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Quests/AvoidQuests/Enabled", false, "false"));
             FocusBlacklist = Helpers.ReadNode(rootNode, "Quests/AvoidQuests/QuestList", false, "none") != "none" ? Helpers.ReadNode(rootNode, "Quests/AvoidQuests/QuestList").Split(';') : new string[0];
             AutoClaimSeasonRewards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Season/AutoClaimSeasonRewards", false, "false"));
@@ -109,12 +120,17 @@ namespace SplinterlandsRObot.Player
             UseStarterCards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "Cards/UseStarterCards", false, "true"));
             ClaimSPS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/Airdrops/CollectSPS", false, "false"));
             CheckForAirdropEvery = Convert.ToInt32(Helpers.ReadNode(rootNode, "ProFeatures/Airdrops/CheckForAirdropEvery", false, "5"));
+            ClaimSPSRewards = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/SPS/ClaimSPSRewards", false, "false"));
+            ClaimSPSRewardsEvery = Convert.ToInt32(Helpers.ReadNode(rootNode, "ProFeatures/SPS/ClaimSPSRewardsEvery", false, "24"));
+            UnstakeSPS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/SPS/UnstakeSPS", false, "false"));
+            MinimumSPSUnstakeAmount = Convert.ToDouble(Helpers.ReadNode(rootNode, "ProFeatures/SPS/MinimumSPSUnstakeAmount", false, "100"));
+            UnstakeWeekly = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/SPS/UnstakeWeekly", false, "false"));
             EnableRentals = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/UseRentalBot", false, "false"));
-            PowerLimit = Convert.ToInt32(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/PowerLimit", false, "0"));
             BattleWhileRenting = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/BattleWhileRenting", false, "false"));
             DaysToRent = Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/DaysToRent", false, "1");
             MaxTriesPerAccount = Convert.ToInt32(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/MaxTriesPerUser", false, "999999"));
             UseRentFile = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/RentSpecificCards", false, "false"));
+            GroupCardsAmount = Convert.ToInt32(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/GroupCardsAmount", false, "5"));
             RentFile = Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/RentFile", false, "false");
             RentForPower = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/RentForPower", false, "false"));
             RentGoldCardsOnly = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/RentalBot/RentGoldOnly", false, "false"));

--- a/SplinterlandsRObot/Player/PlayerFocus/Focus.cs
+++ b/SplinterlandsRObot/Player/PlayerFocus/Focus.cs
@@ -59,7 +59,7 @@ namespace SplinterlandsRObot.Player.PlayerFocus
         {
             try
             {
-                string tx = new HiveActions().ClaimQuest(user, id);
+                string tx = new HiveService().ClaimQuest(user, id);
                 Logs.LogMessage($"{user.Username}: Claimed Daily Focus reward. Tx:{tx}");
 
                 return tx;
@@ -78,7 +78,7 @@ namespace SplinterlandsRObot.Player.PlayerFocus
                 if (IsFocusClaimed() && earned_chests > 0)
                 {
                     Logs.LogMessage($"{user.Username}: New daily Focus available, requesting from Splinterlands...");
-                    string tx = new HiveActions().StartFocus(user);
+                    string tx = new HiveService().StartFocus(user);
                     if (tx != null)
                     {
                         return tx;
@@ -91,7 +91,7 @@ namespace SplinterlandsRObot.Player.PlayerFocus
                 else if (!IsFocusClaimed() && earned_chests == 0)
                 {
                     Logs.LogMessage($"{user.Username}: New daily Focus available, requesting from Splinterlands...");
-                    string tx = new HiveActions().StartFocus(user);
+                    string tx = new HiveService().StartFocus(user);
                     if (tx != null)
                     {
                         return tx;
@@ -113,7 +113,7 @@ namespace SplinterlandsRObot.Player.PlayerFocus
         {
             if (!IsFocusCompleted() && !IsFocusClaimed())
             {
-                string tx = new HiveActions().NewQuest(user);
+                string tx = new HiveService().NewQuest(user);
                 if (tx != null)
                 {
                     return tx;

--- a/SplinterlandsRObot/Player/PlayerFocus/FocusReward.cs
+++ b/SplinterlandsRObot/Player/PlayerFocus/FocusReward.cs
@@ -3,7 +3,7 @@
     public class FocusReward
     {
         public string type { get; set; }
-        public int quantity { get; set; }
+        public double quantity { get; set; }
         public RewardCard card { get; set; }
         public string potion_type { get; set; }
     }

--- a/SplinterlandsRObot/Player/User.cs
+++ b/SplinterlandsRObot/Player/User.cs
@@ -10,5 +10,7 @@
     {
         public string? ActiveKey { get; set; }
         public string PostingKey { get; set; }
+        public string? JwtToken { get; set; }
+        public DateTime? JwtExpire { get; set; }
     }
 }

--- a/SplinterlandsRObot/Player/UserDetails.cs
+++ b/SplinterlandsRObot/Player/UserDetails.cs
@@ -32,7 +32,6 @@ namespace SplinterlandsRObot.Player
         public int league { get; set; }
         public int? modern_league { get; set; }
         public List<Balance> balances { get; set; }
-        //public List<object> unrevealed_rewards { get; set; }
         public int season_max_league { get; set; }
         public int? modern_season_max_league { get; set; }
         public Focus? quest { get; set; }
@@ -40,8 +39,8 @@ namespace SplinterlandsRObot.Player
         public Season? current_season_player { get; set; }
         public Season? current_modern_season_player { get; set; }
         public Season? previous_season_player { get; set; }
-        public string jwt_token { get; set; }
-        public DateTime jwt_expiration_dt { get; set; }
+        public string? jwt_token { get; set; }
+        public DateTime? jwt_expiration_dt { get; set; }
         public JToken? outstanding_match { get; set; }
     }
     public class SeasonReward

--- a/SplinterlandsRObot/Program.cs
+++ b/SplinterlandsRObot/Program.cs
@@ -67,7 +67,7 @@ class Program
                 }
                 else if (command == "START-CLAIM-SEASON-REWARDS")
                 {
-                    _ = Task.Run(async () => await new HiveActions().ClaimSeasonRewards().ConfigureAwait(false));
+                    _ = Task.Run(async () => await new HiveService().ClaimSeasonRewards().ConfigureAwait(false));
                 }
                 else
                 {

--- a/SplinterlandsRObot/ReleaseNotes.txt
+++ b/SplinterlandsRObot/ReleaseNotes.txt
@@ -1,11 +1,15 @@
-﻿Version 1.1.7-beta
+﻿Version 1.1.8
 
 Changes:
-    - Accounts will no longer need to be all loaded at bot startup
-    - Fixed a bug where Renting Bot would not stop even if CP was above the set limit
-    - Fixed issue claiming season rewards
-    - 2 new config option added
-        - AutoClaimSeasonRewards: will detect when season rewards are available and automatically claim them
-        - AutoTransferAfterSeasonClaim: will trigger the assets transfer once season rewards are claimed
-        Check config example
+    - Changed DoQuest option so it will now control every option for the Quests. If disabled no other Focus option will be used
+    - PowerLimit option has been moved from Renting to the general config area but will still be used by renting process
+    - Added config option (FocusStartMinimumCP) to start a new focus only if CP is above the set PowerLimit
+    - Added config option (FocusMinimumRating) to ignore Focus rate if rating is below the set limit
+    - Added option in settings.xml file to set proxy usage for the bot client
+    - Added config option (GroupCardsAmount) to set the number of cards to be grouped in one renting transaction
+    - Added config options (ClaimSPSRewards, ClaimSPSRewardsEvery) for claiming SPS staked rewards
+    - Added config options (UnstakeSPS, MinimumSPSUnstakeAmount, UnstakeWeekly) for unstaking SPS monthly or weekly
+    - RentSpecificCards option will not get stuck on the first cards of the list, will randomize the list of cards to cover more "ground"
+    - Added Magic on rentals renew process
+    - Adjusted focus rewards to display SPS rewards
 


### PR DESCRIPTION
Changes:
    - Changed DoQuest option so it will now control every option for the Quests. If disabled no other Focus option will be used
    - PowerLimit option has been moved from Renting to the general config area but will still be used by renting process
    - Added config option (FocusStartMinimumCP) to start a new focus only if CP is above the set PowerLimit
    - Added config option (FocusMinimumRating) to ignore Focus rate if rating is below the set limit
    - Added option in settings.xml file to set proxy usage for the bot client
    - Added config option (GroupCardsAmount) to set the number of cards to be grouped in one renting transaction
    - Added config options (ClaimSPSRewards, ClaimSPSRewardsEvery) for claiming SPS staked rewards
    - Added config options (UnstakeSPS, MinimumSPSUnstakeAmount, UnstakeWeekly) for unstaking SPS monthly or weekly
    - RentSpecificCards option will not get stuck on the first cards of the list, will randomize the list of cards to cover more "ground"
    - Added Magic on rentals renew process
    - Adjusted focus rewards to display SPS rewards