### PR TITLE
1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,7 +352,9 @@ MigrationBackup/
 /SplinterlandsApi/*
 /SplinterlandsBrawls/*
 /SplinterlandsShared/*
-/BotApi/BotApi.csproj
-/SplinterlandsRentingIn/SplinterlandsRentingIn.csproj
-/SplinterlandsRentingOut/SplinterlandsRentingOut.csproj
-/HiveEngine/HiveEngine.csproj
+/BotApi/*
+/SplinterlandsRentingIn/*
+/SplinterlandsRentingOut/*
+/HiveEngine/*
+/SplinterlandsRewards/*
+/SplinterlandsAssets/*

--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,10 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 /SplinterlandsRObot/Extensions
+/SplinterlandsApi/*
+/SplinterlandsBrawls/*
+/SplinterlandsShared/*
+/BotApi/BotApi.csproj
+/SplinterlandsRentingIn/SplinterlandsRentingIn.csproj
+/SplinterlandsRentingOut/SplinterlandsRentingOut.csproj
+/HiveEngine/HiveEngine.csproj

--- a/SplinterlandsRObot.sln
+++ b/SplinterlandsRObot.sln
@@ -3,7 +3,25 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31912.275
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsRObot", "SplinterlandsRObot\SplinterlandsRObot.csproj", "{7E91C491-C17A-4DDB-B936-9291A5FDAFDC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SplinterlandsRObot", "SplinterlandsRObot\SplinterlandsRObot.csproj", "{7E91C491-C17A-4DDB-B936-9291A5FDAFDC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsBrawls", "SplinterlandsBrawls\SplinterlandsBrawls.csproj", "{FBFF39F1-274C-4820-BC99-AB362CB70E3E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsApi", "SplinterlandsApi\SplinterlandsApi.csproj", "{32DED593-674E-4556-83B0-7E8E7774435B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsShared", "SplinterlandsShared\SplinterlandsShared.csproj", "{FEFE421F-A2AA-4828-879E-B2868B5E6080}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BotApi", "BotApi\BotApi.csproj", "{0CB15130-15DE-4A25-85EE-3F032F48DDC2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsRentingIn", "SplinterlandsRentingIn\SplinterlandsRentingIn.csproj", "{41DB592A-2853-48F8-B871-CD4E5C31F7AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsRentingOut", "SplinterlandsRentingOut\SplinterlandsRentingOut.csproj", "{612E03B9-F824-477F-A8D0-081511B816AA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "HiveEngine", "HiveEngine\HiveEngine.csproj", "{54541B3F-CF03-4F7F-8C9A-A301612417E5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsRewards", "SplinterlandsRewards\SplinterlandsRewards.csproj", "{99F8C301-77D8-41B0-AEB9-D2087446E214}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SplinterlandsAssets", "SplinterlandsAssets\SplinterlandsAssets.csproj", "{3AA7719C-DC49-4481-B27F-F7785D7D0012}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +33,42 @@ Global
 		{7E91C491-C17A-4DDB-B936-9291A5FDAFDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7E91C491-C17A-4DDB-B936-9291A5FDAFDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7E91C491-C17A-4DDB-B936-9291A5FDAFDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FBFF39F1-274C-4820-BC99-AB362CB70E3E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FBFF39F1-274C-4820-BC99-AB362CB70E3E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FBFF39F1-274C-4820-BC99-AB362CB70E3E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FBFF39F1-274C-4820-BC99-AB362CB70E3E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32DED593-674E-4556-83B0-7E8E7774435B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32DED593-674E-4556-83B0-7E8E7774435B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32DED593-674E-4556-83B0-7E8E7774435B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32DED593-674E-4556-83B0-7E8E7774435B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FEFE421F-A2AA-4828-879E-B2868B5E6080}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FEFE421F-A2AA-4828-879E-B2868B5E6080}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FEFE421F-A2AA-4828-879E-B2868B5E6080}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FEFE421F-A2AA-4828-879E-B2868B5E6080}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0CB15130-15DE-4A25-85EE-3F032F48DDC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0CB15130-15DE-4A25-85EE-3F032F48DDC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0CB15130-15DE-4A25-85EE-3F032F48DDC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0CB15130-15DE-4A25-85EE-3F032F48DDC2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41DB592A-2853-48F8-B871-CD4E5C31F7AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41DB592A-2853-48F8-B871-CD4E5C31F7AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41DB592A-2853-48F8-B871-CD4E5C31F7AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41DB592A-2853-48F8-B871-CD4E5C31F7AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{612E03B9-F824-477F-A8D0-081511B816AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{612E03B9-F824-477F-A8D0-081511B816AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{612E03B9-F824-477F-A8D0-081511B816AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{612E03B9-F824-477F-A8D0-081511B816AA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54541B3F-CF03-4F7F-8C9A-A301612417E5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54541B3F-CF03-4F7F-8C9A-A301612417E5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54541B3F-CF03-4F7F-8C9A-A301612417E5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54541B3F-CF03-4F7F-8C9A-A301612417E5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{99F8C301-77D8-41B0-AEB9-D2087446E214}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{99F8C301-77D8-41B0-AEB9-D2087446E214}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{99F8C301-77D8-41B0-AEB9-D2087446E214}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{99F8C301-77D8-41B0-AEB9-D2087446E214}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3AA7719C-DC49-4481-B27F-F7785D7D0012}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3AA7719C-DC49-4481-B27F-F7785D7D0012}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3AA7719C-DC49-4481-B27F-F7785D7D0012}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3AA7719C-DC49-4481-B27F-F7785D7D0012}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SplinterlandsRObot/Config/config_example.xml
+++ b/SplinterlandsRObot/Config/config_example.xml
@@ -78,7 +78,10 @@
 	  <MininumDecToTransfer>10</MininumDecToTransfer><!--Bot will not trigger a transaction if the remaining amount is less than what is set-->
 	  <TransferSps>false</TransferSps><!--Will transfer SPS currency to main account-->
 	  <TransferPacks>false</TransferPacks><!--Will transfer Packs to main account-->
+	  <TransferVouchers>false</TransferVouchers><!--Will transfer Vouchers to main account-->
 	</TransferBot>
-	<SyncBotStats>false</SyncBotStats><!--Sync the user statistics with the server, you can check them on the bot website using the generated passkey-->
+	<RequestDecFromMain>false</RequestDecFromMain><!--(!! this option requires main_account.xml file to be configured)Will allow the user to trigger a request to the main account in order to receive DEC-->
+	<DesiredDecAmount>0</DesiredDecAmount><!--The amount of DEC the account should have after refill-->
+	<RequestWhenDecBelow>0</RequestWhenDecBelow><!--The DEC balance below which the user will trigger the request-->
   </ProFeatures>
 </config>

--- a/SplinterlandsRObot/Config/main_account_example.xml
+++ b/SplinterlandsRObot/Config/main_account_example.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<user>
+	<username>username</username>Hive username withous @-->
+	<postingKEY>5XXXX</postingKEY>
+	<activeKEY>5XXXX</activeKEY>
+</user>

--- a/SplinterlandsRObot/Config/settings_example.xml
+++ b/SplinterlandsRObot/Config/settings_example.xml
@@ -4,7 +4,7 @@
 	<MaxThreads>1</MaxThreads><!--The number of accounts the bot will play in parallel-->
 	
 	<DebugMode>false</DebugMode><!--Just enable this if you have issues, will diplay a lot more logs in the console-->
-	<ApiUrl>http://api.splinterlandsrobot.com:5000</ApiUrl><!--DON'T CHANGE THIS UNLESS INSTRUCTED SO-->
+	<ApiUrl>http://botapi.splinterlandsrobot.com:5000</ApiUrl><!--DON'T CHANGE THIS UNLESS INSTRUCTED SO-->
 	<HiveNode>https://anyx.io/</HiveNode><!--Hive blockchain node address-->
 	<Proxy><!--Proxy usage when calling Splinterlands API-->
 		<ProxyUrl></ProxyUrl>

--- a/SplinterlandsRObot/Global/Constants.cs
+++ b/SplinterlandsRObot/Global/Constants.cs
@@ -3,7 +3,7 @@
     public static class Constants
     {
         public const string SPLINTERLANDS_WEBSOCKET_URL = "wss://ws2.splinterlands.com/";
-        public const string APP_VERSION = "SplinterlandsRObot 1.1.8";
+        public const string APP_VERSION = "SplinterlandsRObot 1.2.0";
         public const string SPLINTERLANDS_BATTLE_API = "https://battle.splinterlands.com";
         public const string USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:93.0) Gecko/20100101 Firefox/93.0";
         public const string CONFIG_FOLDER = "Config";

--- a/SplinterlandsRObot/Global/Helpers.cs
+++ b/SplinterlandsRObot/Global/Helpers.cs
@@ -59,7 +59,7 @@ namespace SplinterlandsRObot.Global
         }
         public static string RandomString(int length)
         {
-            const string chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+            const string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
             Random random = new Random();
             return new string(Enumerable.Repeat(chars, length)
               .Select(s => s[random.Next(s.Length)]).ToArray());

--- a/SplinterlandsRObot/Global/InstanceManager.cs
+++ b/SplinterlandsRObot/Global/InstanceManager.cs
@@ -16,15 +16,18 @@ namespace SplinterlandsRObot
         public static List<BotInstance> BotInstances = new();
         public static List<User> userList = new();
         public static List<UserStats> UsersStatistics = new();
-        public static Dictionary<string,int> RentingQueue = new();
+        public static Dictionary<string, int> RentingQueue = new();
+        public static Dictionary<string, BotInstance> DecTransferQueue = new();
         public static object StartBattleLock = new();
         public static HttpClient HttpClient = new();
         public static CookieContainer CookieContainer = new();
         public static bool isRentingServiceRunning = false;
         public static bool isRenewRentingServiceRunning = false;
         public static bool isStatsSyncRunning = false;
+        public static bool isDecDistributorRunning = false;
         private static FileSystemWatcher _fsWatcher = new FileSystemWatcher();
         public static Subject<string> _configs = new Subject<string>();
+        
         public static IObservable<string> Configs => _configs.AsObservable();
         public static void CreateUsersInstance()
         {
@@ -89,6 +92,13 @@ namespace SplinterlandsRObot
                     {
                         _ = Task.Run(async () => await new Bot().SyncUserStats(identifier, token).ConfigureAwait(false));
                         isStatsSyncRunning = true;
+                        Task.Delay(1500);
+                    }
+
+                    if (!isDecDistributorRunning)
+                    {
+                        _ = Task.Run(async () => await new DecDistributor().Start().ConfigureAwait(false));
+                        isDecDistributorRunning = true;
                         Task.Delay(1500);
                     }
                 }

--- a/SplinterlandsRObot/Net/WebClient.cs
+++ b/SplinterlandsRObot/Net/WebClient.cs
@@ -13,6 +13,7 @@ namespace SplinterlandsRObot.Net
 
         public WebClient(string url, string? origin = "", string? referer = "", string? proxyUrl = null, string? proxyPort = null, string? proxyUser = null, string? proxyPassword = null)
         {
+            httpClientHandler= new HttpClientHandler() { AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate | DecompressionMethods.Brotli };
             if (proxyUrl is not null && proxyPort is not null)
             {
                 proxy = new WebProxy()
@@ -31,7 +32,7 @@ namespace SplinterlandsRObot.Net
 
             if (proxy is not null)
             {
-                httpClientHandler = new HttpClientHandler() { Proxy = proxy };
+                httpClientHandler.Proxy = proxy;
             }
 
             if (httpClientHandler is not null)
@@ -45,6 +46,7 @@ namespace SplinterlandsRObot.Net
             client.DefaultRequestHeaders.Add("referer", referer);
             client.DefaultRequestHeaders.Add("accept", "application/json, text/plain, */*");
             client.DefaultRequestHeaders.Add("user-agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.5060.114 Safari/537.36");
+            client.DefaultRequestHeaders.Add("accept-encoding", "gzip, deflate, br");
         }
 
         public async Task<string> PostAsync(string postData, string path)

--- a/SplinterlandsRObot/Player/Config.cs
+++ b/SplinterlandsRObot/Player/Config.cs
@@ -74,6 +74,12 @@ namespace SplinterlandsRObot.Player
         public double MinimumDecToTransfer { get; set; }
         public bool TransferSPS { get; set; }
         public bool TransferPacks { get; set; }
+        public bool TransferVouchers { get; set; }
+
+        //Dec Distributor
+        public bool RequestDecFromMain { get; set; }
+        public double DesiredDecAmount { get; set; }
+        public double RequestWhenDecBelow { get; set; }
 
         private string _filename;
 
@@ -147,7 +153,11 @@ namespace SplinterlandsRObot.Player
             MinimumDecToTransfer = Convert.ToDouble(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/MininumDecToTransfer", false, "10"));
             TransferSPS = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/TransferSps", false, "false"));
             TransferPacks = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/TransferPacks", false, "false"));
+            TransferVouchers = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/TransferBot/TransferVouchers", false, "false"));
             UsePrivateApi = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/UsePrivateAPi", false, "false"));
+            RequestDecFromMain = Convert.ToBoolean(Helpers.ReadNode(rootNode, "ProFeatures/RequestDecFromMain", false, "false"));
+            DesiredDecAmount = Convert.ToDouble(Helpers.ReadNode(rootNode, "ProFeatures/DesiredDecAmount", false, "0"));
+            RequestWhenDecBelow = Convert.ToDouble(Helpers.ReadNode(rootNode, "ProFeatures/RequestWhenDecBelow", false, "0"));
         }
 
         private void OnConfigChanged(string filename)

--- a/SplinterlandsRObot/ReleaseNotes.txt
+++ b/SplinterlandsRObot/ReleaseNotes.txt
@@ -1,7 +1,9 @@
-﻿Version 1.1.9
+﻿Version 1.2.0
 
 Changes:
-    - Fixed the error causing rental process to restart when the card is not on the market
-    - Updated claim SPS rewards to work with the latest changes in the game
-    - Other minor adjustements
+    - Fixed an issue reading player balance in RentForPower
+    - Fixed an issue reading player balance in RenewRentals
+    - Fixed a bug in AssetsTransfer that would prevent cards from being transfered if some are listed for Sale/Rent
+    - Added option to transfer Vouchers to main account. Check "TransferVouchers" in config_example
+    - Added option to request DEC refill from main account. Requires main_account.xml file to be configured, check main_account_example.xml
 

--- a/SplinterlandsRObot/ReleaseNotes.txt
+++ b/SplinterlandsRObot/ReleaseNotes.txt
@@ -6,4 +6,5 @@ Changes:
     - Fixed a bug in AssetsTransfer that would prevent cards from being transfered if some are listed for Sale/Rent
     - Added option to transfer Vouchers to main account. Check "TransferVouchers" in config_example
     - Added option to request DEC refill from main account. Requires main_account.xml file to be configured, check main_account_example.xml
+    - Updated Api calls to accept compression
 

--- a/SplinterlandsRObot/SplinterlandsRObot.csproj
+++ b/SplinterlandsRObot/SplinterlandsRObot.csproj
@@ -30,6 +30,9 @@
     <None Update="Config\config_example.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Config\main_account_example.xml">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Config\rentcards_example.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
Version 1.2.0

Changes:
    - Fixed an issue reading player balance in RentForPower
    - Fixed an issue reading player balance in RenewRentals
    - Fixed a bug in AssetsTransfer that would prevent cards from being transfered if some are listed for Sale/Rent
    - Added option to transfer Vouchers to main account. Check "TransferVouchers" in config_example
    - Added option to request DEC refill from main account. Requires main_account.xml file to be configured, check main_account_example.xml
    - Updated Api calls to accept compression